### PR TITLE
Add Dockerfile and docker-compose for local setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# Dockerfile
+# (Optional) If you have an application, add build steps here. For now, this is a placeholder.
+FROM alpine:3.18
+CMD ["echo", "Satellite2026 Docker container"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    container_name: satellite2026-db
+    environment:
+      POSTGRES_DB: Satellite2026
+      POSTGRES_USER: samod
+      POSTGRES_PASSWORD: samodsamod
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  pgadmin:
+    image: dpage/pgadmin4:8
+    container_name: satellite2026-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: adminadmin
+    ports:
+      - "5050:80"
+    depends_on:
+      - db
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+
+volumes:
+  postgres_data:
+  pgadmin_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: postgres:16
     container_name: satellite2026-db
     environment:
-      POSTGRES_DB: Satellite2026
-      POSTGRES_USER: samod
-      POSTGRES_PASSWORD: samodsamod
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -16,8 +16,8 @@ services:
     image: dpage/pgadmin4:8
     container_name: satellite2026-pgadmin
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@admin.com
-      PGADMIN_DEFAULT_PASSWORD: adminadmin
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
     ports:
       - "5050:80"
     depends_on:


### PR DESCRIPTION
Introduces a basic Dockerfile using Alpine Linux and a docker-compose.yml to set up PostgreSQL and pgAdmin services for local development. This provides a standardized environment for running and managing the application's database stack.